### PR TITLE
Fix overly eager caching

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending Release
 ---------------
 
 * (Insert new release notes below this line)
+* Fix a bug where cached values in 'edit' would be reused when changing the
+  app, stage, or variable names, which change the KMS encryption context.
 
 1.2.0 (2017-08-31)
 ------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from treehugger.kms import kms_agent
 
 @pytest.fixture(scope='function', autouse=True)
 def kms_stub():
-    kms_agent.cache = {}
+    kms_agent.reset()
     with Stubber(kms_agent.kms_client) as stubber:
         yield stubber
         stubber.assert_no_pending_responses()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from treehugger.kms import kms_agent
 
 @pytest.fixture(scope='function', autouse=True)
 def kms_stub():
+    kms_agent.cache = {}
     with Stubber(kms_agent.kms_client) as stubber:
         yield stubber
         stubber.assert_no_pending_responses()

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -1,0 +1,118 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import base64
+
+from treehugger.kms import kms_agent
+
+
+class TestKMSAgent:
+
+    def test_decrypt(self, kms_stub):
+        context = {'foo': 'bar'}
+        kms_stub.add_response(
+            'decrypt',
+            expected_params={
+                'CiphertextBlob': b'baz',
+                'EncryptionContext': context
+            },
+            service_response={
+                'KeyId': 'treehugger',
+                'Plaintext': b'qux',
+            }
+        )
+
+        plaintext = kms_agent.decrypt(base64.b64encode(b'baz'), context)
+
+        assert plaintext == 'qux'
+
+    def test_encrypt(self, kms_stub):
+        context = {'foo': 'bar'}
+        kms_stub.add_response(
+            'encrypt',
+            expected_params={
+                'KeyId': 'alias/treehugger',
+                'Plaintext': b'baz',
+                'EncryptionContext': context
+            },
+            service_response={
+                'KeyId': 'treehugger',
+                'CiphertextBlob': b'qux',
+            }
+        )
+
+        ciphertext_blob = kms_agent.encrypt('baz', context)
+
+        assert ciphertext_blob == base64.b64encode(b'qux')
+
+    def test_decrypt_encrypt_cached(self, kms_stub):
+        context = {'foo': 'bar'}
+        kms_stub.add_response(
+            'decrypt',
+            expected_params={
+                'CiphertextBlob': b'baz',
+                'EncryptionContext': context
+            },
+            service_response={
+                'KeyId': 'treehugger',
+                'Plaintext': b'qux',
+            }
+        )
+
+        plaintext = kms_agent.decrypt(base64.b64encode(b'baz'), context)
+        ciphertext_blob = kms_agent.encrypt(plaintext, context)
+
+        assert ciphertext_blob == base64.b64encode(b'baz')
+
+    def test_encrypt_encrypt_cached(self, kms_stub):
+        context = {'foo': 'bar'}
+        kms_stub.add_response(
+            'encrypt',
+            expected_params={
+                'KeyId': 'alias/treehugger',
+                'Plaintext': b'baz',
+                'EncryptionContext': context
+            },
+            service_response={
+                'KeyId': 'treehugger',
+                'CiphertextBlob': b'qux',
+            }
+        )
+
+        kms_agent.encrypt('baz', context)
+        ciphertext_blob = kms_agent.encrypt('baz', context)
+
+        assert ciphertext_blob == base64.b64encode(b'qux')
+
+    def test_decrypt_encrypt_context_change_no_cache(self, kms_stub):
+        context = {'foo': 'bar'}
+        context2 = {'foo': 'bar2'}
+        kms_stub.add_response(
+            'decrypt',
+            expected_params={
+                'CiphertextBlob': b'baz',
+                'EncryptionContext': context
+            },
+            service_response={
+                'KeyId': 'treehugger',
+                'Plaintext': b'qux',
+            }
+        )
+        kms_stub.add_response(
+            'encrypt',
+            expected_params={
+                'KeyId': 'alias/treehugger',
+                'Plaintext': b'qux',
+                'EncryptionContext': context2,
+            },
+            service_response={
+                'KeyId': 'treehugger',
+                'CiphertextBlob': b'quux',
+            }
+        )
+
+        plaintext = kms_agent.decrypt(base64.b64encode(b'baz'), context)
+        ciphertext_blob = kms_agent.encrypt(plaintext, context2)
+        print(base64.b64decode(ciphertext_blob))
+
+        assert ciphertext_blob == base64.b64encode(b'quux')

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -113,6 +113,5 @@ class TestKMSAgent:
 
         plaintext = kms_agent.decrypt(base64.b64encode(b'baz'), context)
         ciphertext_blob = kms_agent.encrypt(plaintext, context2)
-        print(base64.b64decode(ciphertext_blob))
 
         assert ciphertext_blob == base64.b64encode(b'quux')

--- a/treehugger/kms.py
+++ b/treehugger/kms.py
@@ -11,10 +11,13 @@ from .ec2 import get_current_region
 
 class KMSAgent(object):
 
+    key_id = 'alias/treehugger'
+
     def __init__(self):
         self.cache = {}
 
-    key_id = 'alias/treehugger'
+    def reset(self):
+        self.cache = {}
 
     @property
     def kms_client(self):


### PR DESCRIPTION
Fixes #65. The KMS agent is now independently tested, and as a bonus 'encrypt' will also store values in the cache, which will help with programmatic invocations of treehugger.