### PR TITLE
improvements to ignore-missing option

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Pending Release
 
 * (Insert new release notes below this line)
 
+* Add `--ignore-missing` argument to `exec` command to allow it to run when user-data isn't configured for the current EC2 instance
+
 2.0.0 (2017-09-25)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,8 @@ Pending Release
 
 * (Insert new release notes below this line)
 
-* Add `--ignore-missing` argument to `exec` command to allow it to run when user-data isn't configured for the current EC2 instance
+* Add `--ignore-missing` argument to `exec` command to allow it to run when 
+  user-data isn't configured for the current EC2 instance
 
 2.0.0 (2017-09-25)
 ------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -311,6 +311,23 @@ class TestCLI:
             'TREEHUGGER_STAGE': 'qux',
         }
 
+    @responses.activate
+    def test_exec_with_ignore_missing(self, kms_stub, capsys):
+        responses.add(
+            responses.GET,
+            USER_DATA_URL,
+            status=404,
+        )
+
+        with mock.patch('os.execlp') as mock_execlp, mock.patch('os.environ', new={}) as mock_environ:
+            main(['exec', '--ignore-missing', '--', 'env'])
+
+        mock_execlp.assert_called_with('env', 'env')
+        assert mock_environ == {
+            'TREEHUGGER_APP': 'Missing',
+            'TREEHUGGER_STAGE': 'Missing',
+        }
+
     def test_exec_file(self, tmpdir, kms_stub):
         tmpfile = tmpdir.join('test.yml')
         encrypted_var = base64.b64encode(b'foo')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,11 +313,7 @@ class TestCLI:
 
     @responses.activate
     def test_exec_with_ignore_missing(self, kms_stub, capsys):
-        responses.add(
-            responses.GET,
-            USER_DATA_URL,
-            status=404,
-        )
+        responses.add(responses.GET, USER_DATA_URL, status=404)
 
         with mock.patch('os.execlp') as mock_execlp, mock.patch('os.environ', new={}) as mock_environ:
             main(['exec', '--ignore-missing', '--', 'env'])

--- a/treehugger/cli/execute.py
+++ b/treehugger/cli/execute.py
@@ -22,7 +22,7 @@ exec_parser.add_argument('-f', '--file', type=str, default=None, dest='filename'
 exec_parser.add_argument('command', nargs=argparse.REMAINDER)
 
 exec_parser.add_argument('-i', '--ignore-missing', action='store_true', dest='ignoremissing',
-                         help='Don\'t die if there are no variables')
+                         help="Don't die if there are no variables")
 
 
 def execute(args):

--- a/treehugger/ec2.py
+++ b/treehugger/ec2.py
@@ -23,13 +23,11 @@ def load_user_data_as_yaml_or_die(ignore_missing=False):
         data = load_user_data_as_yaml()
     except (ConnectTimeout, ConnectionError):
         die('Could not connect to EC2 metadata service - are we on an EC2 instance?')
-        raise SystemExit(1)
     except HTTPError as exc:
         if exc.response.status_code == 404 and ignore_missing:
             return {'TREEHUGGER_APP': 'Missing', 'TREEHUGGER_STAGE': 'Missing'}
 
         die('Got a {} from the EC2 metadata service when retrieving user data'.format(exc.response.status_code))
-        raise SystemExit(1)
     except yaml.error.YAMLError:
         die('Did not find valid YAML in the EC2 user data')
 

--- a/treehugger/ec2.py
+++ b/treehugger/ec2.py
@@ -25,8 +25,11 @@ def load_user_data_as_yaml_or_die(ignore_missing=False):
         die('Could not connect to EC2 metadata service - are we on an EC2 instance?')
         raise SystemExit(1)
     except HTTPError as exc:
-        if not ignore_missing:
-            die('Got a {} from the EC2 metadata service when retrieving user data'.format(exc.response.status_code))
+        if exc.response.status_code == 404 and ignore_missing:
+            return {'TREEHUGGER_APP': 'Missing', 'TREEHUGGER_STAGE': 'Missing'}
+
+        die('Got a {} from the EC2 metadata service when retrieving user data'.format(exc.response.status_code))
+        raise SystemExit(1)
     except yaml.error.YAMLError:
         die('Did not find valid YAML in the EC2 user data')
 


### PR DESCRIPTION
previous attempt was incomplete, I've tested this behaves as expect on an ec2 instance for which 404 is retruned